### PR TITLE
update sha512 integrity - animate.min.css

### DIFF
--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -151,7 +151,7 @@ results|map(attribute='template')|unique|list|count == 1 %} {% set only_template
         <link
             rel="stylesheet"
             href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"
-            integrity="sha512-mlA9t6ceBZ2YtJbK3BZ2quKjz0cm6eHh4WP+9E0Qm01l6kVv9Jh2fXN1f9w+G5m7O3dGw0FJfFQnlw1YJXvGmg=="
+            integrity="sha512-c42qTSw/wPZ3/5LBzD+Bw5f7bSF2oxou6wEb+I/lqeaKV5FDIfMvvRp772y4jcJLKuGUOpbJMdg/BTl50fJYAw=="
             crossorigin="anonymous"
             referrerpolicy="no-referrer"
         />


### PR DESCRIPTION
## What does this PR do?

Updates sha512 integrity for [animate.min.css](https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css) to `sha512-c42qTSw/wPZ3/5LBzD+Bw5f7bSF2oxou6wEb+I/lqeaKV5FDIfMvvRp772y4jcJLKuGUOpbJMdg/BTl50fJYAw==`
https://www.srihash.org

## Why is this change important?

Allows animate.min.css to load
![image](https://github.com/moa-engine/MOA/assets/20036947/1d5f568d-4217-4946-b2cd-cf336028d92c)


## How to test this PR locally?

 - pull changes
 
 - `make run` 
