### PR TITLE
Add GitHub Actions for Auto Docker Build and Push to the Container registry

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,50 @@
+name: Create and publish a Docker image
+
+on:
+#  push:
+#    branches:
+#      - master
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /usr/local/searxng
 
 COPY requirements.txt ./requirements.txt
 # for download packages in iran we must use proxy
-ENV HTTPS_PROXY="http://fodev.org:8118"
+# ENV HTTPS_PROXY="http://fodev.org:8118"
 RUN apk add --no-cache -t build-dependencies \
     build-base \
     py3-setuptools \


### PR DESCRIPTION
## What does this PR do?

This PR adds GitHub Actions to automate Docker build and push processes to the container registry. It includes configuration files and scripts necessary for setting up the workflow.

## Why is this change important?

Automating Docker builds and pushes streamlines the deployment process, ensuring consistency and reliability especially in Iran where working with DockerHub might get challenging. It reduces manual errors and simplifies the release management.

## How to test this PR locally?

This PR is based on GitHub Actions and does not require changes to local project code. Therefore, testing locally involves verifying that the GitHub Actions workflow executes successfully and correctly pushes Docker images to the container registry.

## Author's checklist

Ensure the GitHub Actions workflow builds and pushes the Docker image only when a GitHub release is performed.

## Related issues

none
